### PR TITLE
Enable jsx-no-bind

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -16,6 +16,7 @@
     "react/jsx-equals-spacing": [2, "never"],
     "react/jsx-indent": [2, 2],
     "react/jsx-indent-props": [2, 2],
+    "react/jsx-no-bind": 2,
     "react/jsx-no-duplicate-props": 2,
     "react/jsx-no-undef": 2,
     "react/jsx-space-before-closing": 2,


### PR DESCRIPTION
Creating new functions in render and passing them as props is bad for performance.

See: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md
