### PR TITLE
jsx-space-before-closing rule is deprecated

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -21,7 +21,9 @@
     "react/jsx-indent-props": ["error", 2],
     "react/jsx-no-duplicate-props": "error",
     "react/jsx-no-undef": "error",
-    "react/jsx-space-before-closing": "error",
+    "react/jsx-tag-spacing": {
+      "beforeSelfClosing": "always"
+    },
     "react/jsx-uses-react": "error",
     "react/jsx-uses-vars": "error",
     "react/self-closing-comp": "error"


### PR DESCRIPTION
See https://github.com/yannickcr/eslint-plugin-react/blob/3743e6de53cedec3ee600d520f13643b4ce1df20/docs/rules/jsx-space-before-closing.md