### PR TITLE
Ignore node_modules from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
Add `node_modules` to `.gitignore` for convenience in avoiding committing it.