### PR TITLE
Enforce no spaces before closing brackets

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -20,7 +20,10 @@
     "react/jsx-indent-props": ["error", 2],
     "react/jsx-no-duplicate-props": "error",
     "react/jsx-no-undef": "error",
-    "react/jsx-tag-spacing": ["error", { "beforeSelfClosing": "always" }],
+    "react/jsx-tag-spacing": ["error", {
+      "beforeSelfClosing": "always",
+      "beforeClosing": "never"
+    }],
     "react/jsx-uses-react": "error",
     "react/jsx-uses-vars": "error",
     "react/self-closing-comp": "error"

--- a/test/validate-config.js
+++ b/test/validate-config.js
@@ -14,3 +14,57 @@ test('load config in eslint to validate all rule syntax is correct', function (t
   t.equal(cli.executeOnText(code).errorCount, 0)
   t.end()
 })
+
+test('space before an opening tag\'s closing bracket should not be allowed', t => {
+  const CLIEngine = eslint.CLIEngine
+
+  const cli = new CLIEngine({
+    useEslintrc: false,
+    configFile: 'eslintrc.json'
+  })
+
+  const shouldPass = {
+    selfClosing: `<div />`,
+    withChildren: `
+      <div>
+        test
+      </div>
+    `,
+    withChildrenWithPropsMultiLine: `
+      <div
+        a
+        b
+      >
+        test
+      </div>
+    `
+  }
+
+  const shouldFail = {
+    selfClosing: `<div/ >`,
+    openingTag: `
+      <div >
+        test
+      </div>
+    `,
+    closingTag: `
+      <div>
+        test
+      </div >
+    `
+  }
+
+  const testPlansCount = Object.keys(shouldPass).length + Object.keys(shouldFail).length
+
+  t.plan(testPlansCount)
+
+  for (const testCase in shouldPass) {
+    const { errorCount } = cli.executeOnText(shouldPass[testCase])
+    t.equal(errorCount, 0)
+  }
+
+  for (const testCase in shouldFail) {
+    const { errorCount } = cli.executeOnText(shouldFail[testCase])
+    t.true(errorCount > 0)
+  }
+})


### PR DESCRIPTION
Fixes https://github.com/standard/standard/issues/1348.

Enforce no spaces before closing brackets and also add test cases.

There's some duplicate code around setting up `eslint.CLIEngine` in the tests which I hope to improve in a separate PR so this PR is focused only on the linked issue above.