### PR TITLE
feat: support ESLint 8.x

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,39 @@
+name: validate
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  main:
+    strategy:
+      matrix:
+        eslint: [7.12.1, 7, 8.0.0, 8]
+        node: [12.22.0, 12, 14.17.0, 14, 16.0.0, 16]
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v2
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: 📥 Download deps
+        uses: bahmutov/npm-install@v1
+        with:
+          useLockFile: false
+
+      - name: Install ESLint v${{ matrix.eslint }}
+        run: npm install --no-save --force eslint@${{ matrix.eslint }}
+
+      - name: ▶️ Run tests
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,1 @@
 node_modules
-.DS_Store
-
-# these cause more harm than good
-# when working with contributors
-package-lock.json
-yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
-node_modules/
+node_modules
+.DS_Store
+
+# these cause more harm than good
+# when working with contributors
+package-lock.json
+yarn.lock

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: node_js
-node_js:
-  - lts/*

--- a/package.json
+++ b/package.json
@@ -10,11 +10,6 @@
   "bugs": {
     "url": "https://github.com/standard/eslint-config-standard-jsx/issues"
   },
-  "devDependencies": {
-    "eslint": "^7.12.1",
-    "eslint-plugin-react": "^7.21.5",
-    "tape": "^5.0.1"
-  },
   "homepage": "https://github.com/standard/eslint-config-standard-jsx",
   "keywords": [
     "JavaScript Standard Style",
@@ -45,8 +40,14 @@
   ],
   "license": "MIT",
   "main": "index.js",
+  "dependencies": {},
+  "devDependencies": {
+    "eslint": "^8.7.0",
+    "eslint-plugin-react": "^7.28.0",
+    "tape": "^5.0.1"
+  },
   "peerDependencies": {
-    "eslint": "^7.12.1",
+    "eslint": "^7.12.1 || ^8.0.0",
     "eslint-plugin-react": "^7.21.5"
   },
   "repository": {
@@ -55,6 +56,9 @@
   },
   "scripts": {
     "test": "tape test/*.js"
+  },
+  "engines": {
+    "node": "^10.12.0 || >=12.0.0"
   },
   "funding": [
     {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
   "bugs": {
     "url": "https://github.com/standard/eslint-config-standard-jsx/issues"
   },
+  "devDependencies": {
+    "eslint": "^8.8.0",
+    "eslint-plugin-react": "^7.28.0",
+    "tape": "^5.5.0"
+  },
   "homepage": "https://github.com/standard/eslint-config-standard-jsx",
   "keywords": [
     "JavaScript Standard Style",
@@ -40,15 +45,9 @@
   ],
   "license": "MIT",
   "main": "index.js",
-  "dependencies": {},
-  "devDependencies": {
-    "eslint": "^8.7.0",
-    "eslint-plugin-react": "^7.28.0",
-    "tape": "^5.0.1"
-  },
   "peerDependencies": {
-    "eslint": "^7.12.1 || ^8.0.0",
-    "eslint-plugin-react": "^7.21.5"
+    "eslint": "^8.8.0",
+    "eslint-plugin-react": "^7.28.0"
   },
   "repository": {
     "type": "git",
@@ -56,9 +55,6 @@
   },
   "scripts": {
     "test": "tape test/*.js"
-  },
-  "engines": {
-    "node": "^10.12.0 || >=12.0.0"
   },
   "funding": [
     {

--- a/test/validate-config.js
+++ b/test/validate-config.js
@@ -1,26 +1,22 @@
-const eslint = require('eslint')
+const { ESLint } = require('eslint')
 const test = require('tape')
 
 test('load config in eslint to validate all rule syntax is correct', function (t) {
-  const CLIEngine = eslint.CLIEngine
-
-  const cli = new CLIEngine({
+  const cli = new ESLint({
     useEslintrc: false,
-    configFile: 'eslintrc.json'
+    overrideConfigFile: 'eslintrc.json'
   })
 
   const code = 'var foo = 1\nvar bar = function () {}\nbar(foo)\n'
 
-  t.equal(cli.executeOnText(code).errorCount, 0)
+  t.equal(cli.lintText(code).errorCount, 0)
   t.end()
 })
 
 test('space before an opening tag\'s closing bracket should not be allowed', t => {
-  const CLIEngine = eslint.CLIEngine
-
-  const cli = new CLIEngine({
+  const cli = new ESLint({
     useEslintrc: false,
-    configFile: 'eslintrc.json'
+    overrideConfigFile: 'eslintrc.json'
   })
 
   const shouldPass = {
@@ -59,12 +55,12 @@ test('space before an opening tag\'s closing bracket should not be allowed', t =
   t.plan(testPlansCount)
 
   for (const testCase in shouldPass) {
-    const { errorCount } = cli.executeOnText(shouldPass[testCase])
+    const { errorCount } = cli.lintText(shouldPass[testCase])
     t.equal(errorCount, 0)
   }
 
   for (const testCase in shouldFail) {
-    const { errorCount } = cli.executeOnText(shouldFail[testCase])
+    const { errorCount } = cli.lintText(shouldFail[testCase])
     t.true(errorCount > 0)
   }
 })


### PR DESCRIPTION
ESLint v8.0.0 is [released](https://eslint.org/blog/2021/10/eslint-v8.0.0-released) 🎉

Dependencies should be compatible with ESLint 8 too before we can merge this one:

- [x] [`eslint-plugin-react`](https://github.com/yannickcr/eslint-plugin-react) (https://github.com/yannickcr/eslint-plugin-react/issues/3055)
  - [x] https://github.com/yannickcr/eslint-plugin-react/pull/3059
  - [x] [`v7.27.0`](https://github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md#7270---20211109)

---

Closes #40