### PR TITLE
fix: usage of ES2022 features

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,7 +12,7 @@ jobs:
   main:
     strategy:
       matrix:
-        eslint: [7.12.1, 7, 8.0.0, 8]
+        eslint: [8.0.0, 8]
         node: [12.22.0, 12, 14.17.0, 14, 16.0.0, 16]
     runs-on: ubuntu-latest
     steps:

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "ecmaVersion": 2021,
+    "ecmaVersion": 2022,
     "ecmaFeatures": {
       "jsx": true
     },


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

set `"parserOptions.ecmaVersion": 2022`

**Which issue (if any) does this pull request address?**

Fixes #43

**Is there anything you'd like reviewers to focus on?**

The fix suggested that we remove completely `paserOptions`, but we should be more conservative, maybe there are people using this package alone without `eslint-config-standard`?

Also, it might be the last release of this package in favor of #21, which opened in 2017, I think it will be time to actually do this for the next iteration (not for `standard@17` but probably for `standard@18` next year).

I would say that removing `parserOptions` should be fine but as the current state of nearly EOL of this package, it makes sense to not break too much, of course, feel free to disagree and to discuss. :smile:

Another small thing, I removed ESLint v7 testing in CI as tests were failing, and we already set our `peerDependencies` to only support ESLint `"^8.8.0"` anyway.